### PR TITLE
start publishing an image

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,64 @@
+name: build image
+
+on:
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - "**.rst"
+      - ".github/workflows/*"
+      - "!.github/workflows/publish.yaml"
+  push:
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - "**.rst"
+      - ".github/workflows/*"
+      - "!.github/workflows/publish.yaml"
+    branches-ignore:
+      - "dependabot/**"
+      - "pre-commit-ci-update-config"
+    tags:
+      - "**"
+  workflow_dispatch:
+
+jobs:
+  publish-image:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+
+    services:
+      # So that we can test this in PRs/branches
+      local-registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+
+    steps:
+      - name: Should we push this image to a public registry?
+        run: |
+          if [ "${{ startsWith(github.ref, 'refs/tags/') || (github.ref == 'refs/heads/main') }}" = "true" ]; then
+              echo "REGISTRY=quay.io/" >> $GITHUB_ENV
+          else
+              echo "REGISTRY=localhost:5000/" >> $GITHUB_ENV
+          fi
+
+      - uses: actions/checkout@v4
+
+      - name: Setup push rights to Docker Hub
+        # This was setup by...
+        # 1. Creating a [Robot Account](https://quay.io/organization/jupyterhealth?tab=robots) in the JupyterHub
+        # .  Quay.io org
+        # 2. Giving it enough permissions to push to the singleuser images
+        # 3. Putting the robot account's username and password in GitHub actions environment
+        if: env.REGISTRY != 'localhost:5000/'
+        run: |
+          docker login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" "${{ env.REGISTRY }}"
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: "${{ env.REGISTRY }}jupyterhealth/singleuser-premvp"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM quay.io/jupyter/scipy-notebook:2024-04-01
+
+# make sure jupyterhub version matches
+RUN mamba install jupyterhub==4.1.5 \
+ && mamba clean -pity
+
+# have to do a bit of manual install to avoid commonhealth-cloud pins
+RUN pip install --no-cache tink \
+ && pip install --no-deps commonhealth-cloud-storage-client

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# singleuser-image
-Build singleuser image for Jupyter Health Hub
+# singleuser-image for Jupyter Health pre-mvp
+
+This repo builds and publishes https://quay.io/repository/jupyterhealth/singleuser-premvp for the jupyter health pre-MVP

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # singleuser-image for Jupyter Health pre-mvp
 
 This repo builds and publishes https://quay.io/repository/jupyterhealth/singleuser-premvp for the jupyter health pre-MVP
+
+The image is based on the scipy-notebook Jupyter image,
+adding dependencies for commonhealth cloud API access.


### PR DESCRIPTION
This is very basic for now, but adds the commonhealth-cloud client API to the scipy-notebook base image. 

I've created the repo https://quay.io/repository/jupyterhealth/singleuser-premvp for the image and added a robot account with credentials