### PR TITLE
Added PostgreSQL as a storage delegate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,6 @@ RUN mamba install -y jupyterhub==4.1.5 \
 
 ARG PIP_CACHE_DIR=/tmp/pip-cache
 COPY . /src/
-RUN --mount=type=cache,uid=1000,target=${PIP_CACHE_DIR} \
-    pip install -r /src/requirements.txt /src/
+RUN cd /src/ && \
+    --mount=type=cache,uid=1000,target=${PIP_CACHE_DIR} \
+    pip install -r requirements.txt .

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ RUN mamba install -y jupyterhub==4.1.5 \
 
 ARG PIP_CACHE_DIR=/tmp/pip-cache
 COPY . /src/
-RUN cd /src/ && \
-    --mount=type=cache,uid=1000,target=${PIP_CACHE_DIR} \
+RUN --mount=type=cache,uid=1000,target=${PIP_CACHE_DIR} \
+    cd /src/ && \
     pip install -r requirements.txt .

--- a/jupyter_health/ch_client.py
+++ b/jupyter_health/ch_client.py
@@ -48,7 +48,6 @@ class PSQLStorageDelegate(CHStorageDelegate):
             dbname (optional): the database name, defaults to "postgres"
             user (optional): the database user name, defaults to "postgres"
             port (optional): the exposed port, defaults to 5432
-                If not defined, will be constructed with defaults from the environment
         """
         self.logger = kwargs.get("logger", logging.getLogger(__name__))
         self.logger.info(f"Connecting to {host}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
+.
 # additional requirements to be installed with pip
 black
 jupyterlab-code-formatter
 nbgitpuller
 pre-commit
+psycopg2
 ruff
 voila

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ black
 jupyterlab-code-formatter
 nbgitpuller
 pre-commit
-psycopg2
+psycopg2-binary
 ruff
 voila


### PR DESCRIPTION
- Using `psycopg2` as a driver
- Inspired by `commonhealth_cloud_storage_client.sqlite_delegate.py`

NB: 
- Postgres has a key-value store extension `hstore`. I didn't use it because it looks like it's meant to store key-value metadata per row, instead of being its own table.
- Postgres has JSON support. Also didn't use that
- I'll write tests in the next PR
